### PR TITLE
Add Scilab column and hide/show mechanism

### DIFF
--- a/scientific_modeling_cheatsheet.html
+++ b/scientific_modeling_cheatsheet.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
-<html lang="en">
-<head>
+<html lang="en"><head>
+<meta http-equiv="content-type" content="text/html; charset=UTF-8">
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Scientific Modeling Cheatsheet – MATLAB – Python – Julia Quick Reference</title>
@@ -178,6 +178,31 @@
             background: #2c3e50;
         }
 
+        .hidematlab td:nth-child(2) {
+            display: none;        
+        }
+        .hidematlab th:nth-child(2) {
+            display: none;        
+        }
+        .hidescilab td:nth-child(3) {
+            display: none;        
+        }
+        .hidescilab th:nth-child(3) {
+            display: none;        
+        }
+        .hidepython td:nth-child(4) {
+            display: none;        
+        }
+        .hidepython th:nth-child(4) {
+            display: none;        
+        }
+        .hidejulia td:nth-child(5) {
+            display: none;        
+        }
+        .hidejulia th:nth-child(5) {
+            display: none;        
+        }
+
         td {
             padding: 6px 10px;
             border-bottom: 1px solid #eee;
@@ -209,6 +234,10 @@
             background: #f5f8fe;  /* Julia - Light Blue */
         }
 
+        td:nth-child(5) {
+            background: #fffef0;  /* Julia - Light Yellow */
+        }
+
         tr:last-child td {
             border-bottom: none;
         }
@@ -226,6 +255,10 @@
             background: #f0f5fe;  /* Julia - Slightly darker blue */
         }
 
+        tr:nth-child(even) td:nth-child(5) {
+            background: #fffee9;  /* Julia - Slightly darker blue */
+        }
+
         tr:nth-child(even) td:first-child {
             background: #f5f5f5;
         }
@@ -240,6 +273,10 @@
 
         tr:hover td:nth-child(4) {
             background: #e8f0fe !important;
+        }
+
+        tr:hover td:nth-child(5) {
+            background: #fffbc8 !important;
         }
 
         tr:hover td:first-child {
@@ -452,7 +489,7 @@
                     <li><a href="#optimization">Optimization</a></li>
                     <li><a href="#interpolation">Interpolation</a></li>
                     <li><a href="#integration">Integration</a></li>
-                    <li><a href="#fft">FFT & Signal</a></li>
+                    <li><a href="#fft">FFT &amp; Signal</a></li>
                     <li><a href="#statistics">Statistics</a></li>
                     <li><a href="#pde">PDEs</a></li>
                 </ul>
@@ -471,11 +508,18 @@
         <!-- Main Content -->
         <main class="main-content">
             <h1>Scientific Modeling Cheatsheet</h1>
-            <p class="subtitle">MATLAB – Python – Julia Quick Reference</p>
-
+            <p class="subtitle"><span id="matlab" title="Click to hide/show column">MATLAB</span> – 
+                <span id="scilab" title="Click to hide/show column">Scilab</span> - 
+                <span id="python" title="Click to hide/show column">Python</span> – 
+                <span id="julia" title="Click to hide/show column">Julia</span> Quick Reference (click language to hide/show column)</p>
             <!-- Note about MATLAB code -->
             <div class="note" style="margin-bottom: 30px;">
-                <p><strong>Note on MATLAB Code:</strong> The MATLAB examples from the original QuantEcon sections have been verified. Additional MATLAB examples in the extended scientific computing sections have not been fully tested due to licensing constraints. We welcome community contributions to verify and fix any MATLAB code issues. Please submit corrections via pull request to the repository at <a href="https://github.com/SciML/Julia_Modeling_Workshop" target="_blank">https://github.com/SciML/Julia_Modeling_Workshop</a>.</p>
+                <p><strong>Note on MATLAB Code:</strong> The MATLAB 
+examples from the original QuantEcon sections have been verified. 
+Additional MATLAB examples in the extended scientific computing sections
+ have not been fully tested due to licensing constraints. We welcome 
+community contributions to verify and fix any MATLAB code issues. Please
+ submit corrections via pull request to the repository at <a href="https://github.com/SciML/Julia_Modeling_Workshop" target="_blank">https://github.com/SciML/Julia_Modeling_Workshop</a>.</p>
             </div>
 
             <!-- Dependencies Section -->
@@ -485,6 +529,7 @@
                     <tr>
                         <th>Description</th>
                         <th>MATLAB</th>
+                        <th>Scilab</th>
                         <th>Python</th>
                         <th>Julia</th>
                     </tr>
@@ -493,6 +538,7 @@
                     <tr>
                         <td>Basic numerical</td>
                         <td><code>% Built-in</code></td>
+                        <td><code>// Built-in</code></td>
                         <td><code>import numpy as np
 from numpy import linalg as la</code></td>
                         <td><code>using LinearAlgebra
@@ -502,6 +548,7 @@ using SparseArrays</code></td>
                     <tr>
                         <td>Scientific computing</td>
                         <td><code>% Built-in ODE solvers</code></td>
+                        <td><code>// Built-in ODE solvers</code></td>
                         <td><code>from scipy import integrate
 from scipy import optimize</code></td>
                         <td><code>using DifferentialEquations
@@ -511,6 +558,7 @@ using NonlinearSolve</code></td>
                     <tr>
                         <td>Plotting</td>
                         <td><code>% Built-in plotting</code></td>
+                        <td><code>// Built-in plotting</code></td>
                         <td><code>import matplotlib.pyplot as plt</code></td>
                         <td><code>using Plots</code></td>
                     </tr>
@@ -524,6 +572,7 @@ using NonlinearSolve</code></td>
                     <tr>
                         <th>Description</th>
                         <th>MATLAB</th>
+                        <th>Scilab</th>
                         <th>Python</th>
                         <th>Julia</th>
                     </tr>
@@ -532,11 +581,13 @@ using NonlinearSolve</code></td>
                     <tr>
                         <td>Row vector</td>
                         <td><code>A = [1 2 3]</code></td>
+                        <td><code>A = [1 2 3]</code></td>
                         <td><code>A = np.array([[1, 2, 3]])</code></td>
                         <td><code>A = [1 2 3]</code></td>
                     </tr>
                     <tr>
                         <td>Column vector</td>
+                        <td><code>A = [1; 2; 3]</code></td>
                         <td><code>A = [1; 2; 3]</code></td>
                         <td><code>A = np.array([[1], [2], [3]])</code></td>
                         <td><code>A = [1 2 3]'  # Transpose of row vector
@@ -546,11 +597,13 @@ A = [1, 2, 3]  # 1-D array (column)</code></td>
                     <tr>
                         <td>1-D array</td>
                         <td><code>Not applicable</code></td>
+                        <td><code>Not applicable</code></td>
                         <td><code>A = np.array([1, 2, 3])</code></td>
                         <td><code>A = [1, 2, 3]</code></td>
                     </tr>
                     <tr>
                         <td>Integers from 1 to n</td>
+                        <td><code>A = 1:n</code></td>
                         <td><code>A = 1:n</code></td>
                         <td><code>A = np.arange(1, n+1)</code></td>
                         <td><code>A = 1:n</code></td>
@@ -558,11 +611,13 @@ A = [1, 2, 3]  # 1-D array (column)</code></td>
                     <tr>
                         <td>Integers j to n, step k</td>
                         <td><code>A = j:k:n</code></td>
+                        <td><code>A = j:k:n</code></td>
                         <td><code>A = np.arange(j, n+1, k)</code></td>
                         <td><code>A = j:k:n</code></td>
                     </tr>
                     <tr>
                         <td>Linearly spaced</td>
+                        <td><code>A = linspace(1, 5, k)</code></td>
                         <td><code>A = linspace(1, 5, k)</code></td>
                         <td><code>A = np.linspace(1, 5, k)</code></td>
                         <td><code>A = range(1, 5, length=k)</code></td>
@@ -577,6 +632,7 @@ A = [1, 2, 3]  # 1-D array (column)</code></td>
                     <tr>
                         <th>Description</th>
                         <th>MATLAB</th>
+                        <th>Scilab</th>
                         <th>Python</th>
                         <th>Julia</th>
                     </tr>
@@ -585,11 +641,13 @@ A = [1, 2, 3]  # 1-D array (column)</code></td>
                     <tr>
                         <td>Create matrix</td>
                         <td><code>A = [1 2; 3 4]</code></td>
+                        <td><code>A = [1 2; 3 4]</code></td>
                         <td><code>A = np.array([[1, 2], [3, 4]])</code></td>
                         <td><code>A = [1 2; 3 4]</code></td>
                     </tr>
                     <tr>
                         <td>Zeros</td>
+                        <td><code>A = zeros(2, 2)</code></td>
                         <td><code>A = zeros(2, 2)</code></td>
                         <td><code>A = np.zeros((2, 2))</code></td>
                         <td><code>A = zeros(2, 2)</code></td>
@@ -597,12 +655,14 @@ A = [1, 2, 3]  # 1-D array (column)</code></td>
                     <tr>
                         <td>Ones</td>
                         <td><code>A = ones(2, 2)</code></td>
+                        <td><code>A = ones(2, 2)</code></td>
                         <td><code>A = np.ones((2, 2))</code></td>
                         <td><code>A = ones(2, 2)</code></td>
                     </tr>
                     <tr>
                         <td>Identity</td>
                         <td><code>A = eye(2)</code></td>
+                        <td><code>A = eye(2,2)</code></td>
                         <td><code>A = np.eye(2)</code></td>
                         <td><code>A = I
 A = Matrix(I, 2, 2)</code></td>
@@ -610,11 +670,13 @@ A = Matrix(I, 2, 2)</code></td>
                     <tr>
                         <td>Diagonal</td>
                         <td><code>A = diag([1 2 3])</code></td>
+                        <td><code>A = diag([1 2 3])</code></td>
                         <td><code>A = np.diag([1, 2, 3])</code></td>
                         <td><code>A = Diagonal([1, 2, 3])</code></td>
                     </tr>
                     <tr>
                         <td>Random uniform</td>
+                        <td><code>A = rand(2, 2)</code></td>
                         <td><code>A = rand(2, 2)</code></td>
                         <td><code>A = np.random.rand(2, 2)</code></td>
                         <td><code>A = rand(2, 2)</code></td>
@@ -622,11 +684,13 @@ A = Matrix(I, 2, 2)</code></td>
                     <tr>
                         <td>Random normal</td>
                         <td><code>A = randn(2, 2)</code></td>
+                        <td><code>A = rand(2, 2, "normal")</code></td>
                         <td><code>A = np.random.randn(2, 2)</code></td>
                         <td><code>A = randn(2, 2)</code></td>
                     </tr>
                     <tr>
                         <td>Sparse</td>
+                        <td><code>A = sparse(B)</code></td>
                         <td><code>A = sparse(B)</code></td>
                         <td><code>from scipy import sparse
 A = sparse.csr_matrix(B)</code></td>
@@ -639,7 +703,8 @@ A[2, 2] = 1</code></td>
                     </tr>
                     <tr>
                         <td>Tridiagonal</td>
-                        <td><code>A = diag(x, -1) + diag(y, 0) + diag(z, 1)</code></td>
+                        <td><code>A = diag(x,-1) + diag(y,0) + diag(z,1)</code></td>
+                        <td><code>A = diag(x,-1) + diag(y,0) + diag(z,1)</code></td>
                         <td><code>from scipy.sparse import diags
 A = diags([x, y, z], [-1, 0, 1])</code></td>
                         <td><code># Example vectors
@@ -658,6 +723,7 @@ Tridiagonal(x, y, z)</code></td>
                     <tr>
                         <th>Description</th>
                         <th>MATLAB</th>
+                        <th>Scilab</th>
                         <th>Python</th>
                         <th>Julia</th>
                     </tr>
@@ -665,22 +731,23 @@ Tridiagonal(x, y, z)</code></td>
                 <tbody>
                     <tr>
                         <td>Transpose</td>
-                        <td><code>transpose(A)
-A.'</code></td>
+                        <td><code>A.'</code></td>
+                        <td><code>A.'</code></td>
                         <td><code>A.T</code></td>
-                        <td><code>transpose(A)</code></td>
+                        <td><code>transpose(A)
+A'</code></td>
                     </tr>
                     <tr>
                         <td>Complex conjugate transpose</td>
                         <td><code>A'</code></td>
+                        <td><code>A'</code></td>
                         <td><code>A.conj().T</code></td>
-                        <td><code>A'
-adjoint(A)</code></td>
+                        <td><code>A'</code></td>
                     </tr>
                     <tr>
                         <td>Concatenate horizontally</td>
-                        <td><code>A = [B C]
-A = horzcat(B,C)</code></td>
+                        <td><code>A = [B C]</code></td>
+                        <td><code>A = [B C]</code></td>
                         <td><code>A = np.hstack([B, C])
 A = np.concatenate([B, C], axis=1)</code></td>
                         <td><code>A = [[1 2] [1 2]]  # For literals
@@ -689,8 +756,8 @@ A = hcat(B, C)  # Function form</code></td>
                     </tr>
                     <tr>
                         <td>Concatenate vertically</td>
-                        <td><code>A = [B; C]
-A = vertcat(B,C)</code></td>
+                        <td><code>A = [B; C]</code></td>
+                        <td><code>A = [B; C]</code></td>
                         <td><code>A = np.vstack([B, C])
 A = np.concatenate([B, C], axis=0)</code></td>
                         <td><code>A = [[1 2]; [1 2]]  # For literals
@@ -700,11 +767,13 @@ A = vcat(B, C)  # Function form</code></td>
                     <tr>
                         <td>Reshape (to 5x2)</td>
                         <td><code>A = reshape(A, 5, 2)</code></td>
+                        <td><code>A = matrix(A, 5, 2)</code></td>
                         <td><code>A = A.reshape(5, 2)</code></td>
                         <td><code>A = reshape(A, 5, 2)</code></td>
                     </tr>
                     <tr>
                         <td>Convert matrix to vector</td>
+                        <td><code>A(:)</code></td>
                         <td><code>A(:)</code></td>
                         <td><code>A.flatten()</code></td>
                         <td><code>A[:]
@@ -713,17 +782,20 @@ vec(A)</code></td>
                     <tr>
                         <td>Flip left/right</td>
                         <td><code>fliplr(A)</code></td>
+                        <td><code>flipdim(A,2)</code></td>
                         <td><code>np.fliplr(A)</code></td>
                         <td><code>reverse(A, dims=2)</code></td>
                     </tr>
                     <tr>
                         <td>Flip up/down</td>
                         <td><code>flipud(A)</code></td>
+                        <td><code>flipdim(A,1)</code></td>
                         <td><code>np.flipud(A)</code></td>
                         <td><code>reverse(A, dims=1)</code></td>
                     </tr>
                     <tr>
                         <td>Repeat matrix (3x4 block)</td>
+                        <td><code>repmat(A, 3, 4)</code></td>
                         <td><code>repmat(A, 3, 4)</code></td>
                         <td><code>np.tile(A, (3, 4))</code></td>
                         <td><code>repeat(A, 3, 4)</code></td>
@@ -731,6 +803,7 @@ vec(A)</code></td>
                     <tr>
                         <td>Preallocate similar array</td>
                         <td><code>B = zeros(size(A))</code></td>
+                        <td><code>B = zeros(A)</code></td>
                         <td><code>B = np.empty_like(A)</code></td>
                         <td><code>x = rand(3, 3)
 y = similar(x)
@@ -739,6 +812,7 @@ y = similar(x, 2, 2)</code></td>
                     <tr>
                         <td>Broadcasting functions</td>
                         <td><code>arrayfun(@(x) x^2, A)</code></td>
+                        <td><code>feval(A, #(x)-&gt;(x^2))</code></td>
                         <td><code>A**2  # NumPy broadcasts automatically</code></td>
                         <td><code>f(x) = x^2
 g(x, y) = x + 2 + y^2
@@ -748,19 +822,22 @@ f.(x)  # Apply f to each element
 g.(x, y)  # Apply g element-wise</code></td>
                     </tr>
                     <tr>
-                        <td>Sort each row</td>
+                        <td>Sort rows</td>
                         <td><code>sort(A)</code></td>
+                        <td><code>gsort(A, 1)</code></td>
                         <td><code>np.sort(A)</code></td>
                         <td><code>sort(A, dims=1)</code></td>
                     </tr>
                     <tr>
-                        <td>Sort each column</td>
+                        <td>Sort columns</td>
                         <td><code>sort(A, 2)</code></td>
+                        <td><code>gsort(A, 2)</code></td>
                         <td><code>np.sort(A, axis=1)</code></td>
                         <td><code>sort(A, dims=2)</code></td>
                     </tr>
                     <tr>
                         <td>Unique values</td>
+                        <td><code>unique(A)</code></td>
                         <td><code>unique(A)</code></td>
                         <td><code>np.unique(A)</code></td>
                         <td><code>unique(A)</code></td>
@@ -775,6 +852,7 @@ g.(x, y)  # Apply g element-wise</code></td>
                     <tr>
                         <th>Description</th>
                         <th>MATLAB</th>
+                        <th>Scilab</th>
                         <th>Python</th>
                         <th>Julia</th>
                     </tr>
@@ -783,11 +861,13 @@ g.(x, y)  # Apply g element-wise</code></td>
                     <tr>
                         <td>Access element (row i, col j)</td>
                         <td><code>A(i, j)</code></td>
+                        <td><code>A(i, j)</code></td>
                         <td><code>A[i-1, j-1]</code></td>
                         <td><code>A[i, j]</code></td>
                     </tr>
                     <tr>
                         <td>Access row i</td>
+                        <td><code>A(i, :)</code></td>
                         <td><code>A(i, :)</code></td>
                         <td><code>A[i-1, :]</code></td>
                         <td><code>A[i, :]</code></td>
@@ -795,11 +875,13 @@ g.(x, y)  # Apply g element-wise</code></td>
                     <tr>
                         <td>Access column j</td>
                         <td><code>A(:, j)</code></td>
+                        <td><code>A(:, j)</code></td>
                         <td><code>A[:, j-1]</code></td>
                         <td><code>A[:, j]</code></td>
                     </tr>
                     <tr>
                         <td>First k rows</td>
+                        <td><code>A(1:k, :)</code></td>
                         <td><code>A(1:k, :)</code></td>
                         <td><code>A[:k, :]</code></td>
                         <td><code>A[1:k, :]</code></td>
@@ -807,11 +889,13 @@ g.(x, y)  # Apply g element-wise</code></td>
                     <tr>
                         <td>First k columns</td>
                         <td><code>A(:, 1:k)</code></td>
+                        <td><code>A(:, 1:k)</code></td>
                         <td><code>A[:, :k]</code></td>
                         <td><code>A[:, 1:k]</code></td>
                     </tr>
                     <tr>
                         <td>Last k rows</td>
+                        <td><code>A(end-k+1:end, :)</code></td>
                         <td><code>A(end-k+1:end, :)</code></td>
                         <td><code>A[-k:, :]</code></td>
                         <td><code>A[end-k+1:end, :]</code></td>
@@ -819,11 +903,13 @@ g.(x, y)  # Apply g element-wise</code></td>
                     <tr>
                         <td>Select rows [1, 3, 5]</td>
                         <td><code>A([1 3 5], :)</code></td>
+                        <td><code>A([1 3 5], :)</code></td>
                         <td><code>A[[0, 2, 4], :]</code></td>
                         <td><code>A[[1, 3, 5], :]</code></td>
                     </tr>
                     <tr>
                         <td>Remove row 2</td>
+                        <td><code>A(2, :) = []</code></td>
                         <td><code>A(2, :) = []</code></td>
                         <td><code>A = np.delete(A, 1, axis=0)</code></td>
                         <td><code>A = A[setdiff(1:end, 2), :]</code></td>
@@ -831,11 +917,13 @@ g.(x, y)  # Apply g element-wise</code></td>
                     <tr>
                         <td>Diagonal elements</td>
                         <td><code>diag(A)</code></td>
+                        <td><code>diag(A)</code></td>
                         <td><code>np.diag(A)</code></td>
                         <td><code>diag(A)</code></td>
                     </tr>
                     <tr>
                         <td>Get dimensions</td>
+                        <td><code>size(A)</code></td>
                         <td><code>size(A)</code></td>
                         <td><code>A.shape</code></td>
                         <td><code>size(A)
@@ -844,12 +932,14 @@ nrow, ncol = size(A)</code></td>
                     <tr>
                         <td>Number of dimensions</td>
                         <td><code>ndims(A)</code></td>
+                        <td><code>ndims(A)</code></td>
                         <td><code>A.ndim</code></td>
                         <td><code>ndims(A)</code></td>
                     </tr>
                     <tr>
                         <td>Number of elements</td>
                         <td><code>numel(A)</code></td>
+                        <td><code>length(A)</code></td>
                         <td><code>A.size</code></td>
                         <td><code>length(A)</code></td>
                     </tr>
@@ -863,6 +953,7 @@ nrow, ncol = size(A)</code></td>
                     <tr>
                         <th>Description</th>
                         <th>MATLAB</th>
+                        <th>Scilab</th>
                         <th>Python</th>
                         <th>Julia</th>
                     </tr>
@@ -871,6 +962,7 @@ nrow, ncol = size(A)</code></td>
                     <tr>
                         <td>Dot product</td>
                         <td><code>dot(A, B)</code></td>
+                        <td><code>A(:)'*B(:)</code></td>
                         <td><code>np.dot(A, B)
 A @ B</code></td>
                         <td><code>dot(A, B)
@@ -879,6 +971,7 @@ A ⋅ B</code></td>
                     <tr>
                         <td>Matrix multiplication</td>
                         <td><code>A * B</code></td>
+                        <td><code>A * B</code></td>
                         <td><code>A @ B
 np.matmul(A, B)</code></td>
                         <td><code>A * B</code></td>
@@ -886,11 +979,13 @@ np.matmul(A, B)</code></td>
                     <tr>
                         <td>Element-wise multiplication</td>
                         <td><code>A .* B</code></td>
+                        <td><code>A .* B</code></td>
                         <td><code>A * B</code></td>
                         <td><code>A .* B</code></td>
                     </tr>
                     <tr>
                         <td>Element-wise division</td>
+                        <td><code>A ./ B</code></td>
                         <td><code>A ./ B</code></td>
                         <td><code>A / B</code></td>
                         <td><code>A ./ B</code></td>
@@ -898,11 +993,13 @@ np.matmul(A, B)</code></td>
                     <tr>
                         <td>Element-wise power</td>
                         <td><code>A .^ 2</code></td>
+                        <td><code>A .^ 2</code></td>
                         <td><code>A ** 2</code></td>
                         <td><code>A .^ 2</code></td>
                     </tr>
                     <tr>
                         <td>Matrix power</td>
+                        <td><code>A^2</code></td>
                         <td><code>A^2</code></td>
                         <td><code>np.linalg.matrix_power(A, 2)</code></td>
                         <td><code>A^2</code></td>
@@ -910,17 +1007,20 @@ np.matmul(A, B)</code></td>
                     <tr>
                         <td>Inverse</td>
                         <td><code>inv(A)</code></td>
+                        <td><code>inv(A)</code></td>
                         <td><code>np.linalg.inv(A)</code></td>
                         <td><code>inv(A)</code></td>
                     </tr>
                     <tr>
                         <td>Determinant</td>
                         <td><code>det(A)</code></td>
+                        <td><code>det(A)</code></td>
                         <td><code>np.linalg.det(A)</code></td>
                         <td><code>det(A)</code></td>
                     </tr>
                     <tr>
-                        <td>Eigenvalues & vectors</td>
+                        <td>Eigenvalues &amp; vectors</td>
+                        <td><code>[V, D] = eig(A)</code></td>
                         <td><code>[V, D] = eig(A)</code></td>
                         <td><code>D, V = np.linalg.eig(A)</code></td>
                         <td><code>D, V = eigen(A)</code></td>
@@ -928,11 +1028,13 @@ np.matmul(A, B)</code></td>
                     <tr>
                         <td>Singular value decomposition</td>
                         <td><code>[U, S, V] = svd(A)</code></td>
+                        <td><code>[U, S, V] = svd(A)</code></td>
                         <td><code>U, S, V = np.linalg.svd(A)</code></td>
                         <td><code>U, S, V = svd(A)</code></td>
                     </tr>
                     <tr>
                         <td>Cholesky decomposition</td>
+                        <td><code>chol(A)</code></td>
                         <td><code>chol(A)</code></td>
                         <td><code>np.linalg.cholesky(A)</code></td>
                         <td><code>cholesky(A)</code></td>
@@ -940,11 +1042,13 @@ np.matmul(A, B)</code></td>
                     <tr>
                         <td>LU decomposition</td>
                         <td><code>[L, U, P] = lu(A)</code></td>
+                        <td><code>[L, U, P] = lu(A)</code></td>
                         <td><code>P, L, U = scipy.linalg.lu(A)</code></td>
                         <td><code>L, U, p = lu(A)</code></td>
                     </tr>
                     <tr>
                         <td>QR decomposition</td>
+                        <td><code>[Q, R] = qr(A)</code></td>
                         <td><code>[Q, R] = qr(A)</code></td>
                         <td><code>Q, R = np.linalg.qr(A)</code></td>
                         <td><code>Q, R = qr(A)</code></td>
@@ -952,11 +1056,13 @@ np.matmul(A, B)</code></td>
                     <tr>
                         <td>Rank</td>
                         <td><code>rank(A)</code></td>
+                        <td><code>rank(A)</code></td>
                         <td><code>np.linalg.matrix_rank(A)</code></td>
                         <td><code>rank(A)</code></td>
                     </tr>
                     <tr>
                         <td>Trace</td>
+                        <td><code>trace(A)</code></td>
                         <td><code>trace(A)</code></td>
                         <td><code>np.trace(A)</code></td>
                         <td><code>tr(A)</code></td>
@@ -964,11 +1070,13 @@ np.matmul(A, B)</code></td>
                     <tr>
                         <td>Norm</td>
                         <td><code>norm(A)</code></td>
+                        <td><code>norm(A)</code></td>
                         <td><code>np.linalg.norm(A)</code></td>
                         <td><code>norm(A)</code></td>
                     </tr>
                     <tr>
                         <td>Condition number</td>
+                        <td><code>cond(A)</code></td>
                         <td><code>cond(A)</code></td>
                         <td><code>np.linalg.cond(A)</code></td>
                         <td><code>cond(A)</code></td>
@@ -976,11 +1084,13 @@ np.matmul(A, B)</code></td>
                     <tr>
                         <td>Solve Ax = b</td>
                         <td><code>A \ b</code></td>
+                        <td><code>A \ b</code></td>
                         <td><code>np.linalg.solve(A, b)</code></td>
                         <td><code>A \ b</code></td>
                     </tr>
                     <tr>
                         <td>Least squares</td>
+                        <td><code>A \ b</code></td>
                         <td><code>A \ b</code></td>
                         <td><code>np.linalg.lstsq(A, b)[0]</code></td>
                         <td><code>A \ b</code></td>
@@ -995,6 +1105,7 @@ np.matmul(A, B)</code></td>
                     <tr>
                         <th>Description</th>
                         <th>MATLAB</th>
+                        <th>Scilab</th>
                         <th>Python</th>
                         <th>Julia</th>
                     </tr>
@@ -1003,17 +1114,20 @@ np.matmul(A, B)</code></td>
                     <tr>
                         <td>Sum of all elements</td>
                         <td><code>sum(A(:))</code></td>
+                        <td><code>sum(A)</code></td>
                         <td><code>np.sum(A)</code></td>
                         <td><code>sum(A)</code></td>
                     </tr>
                     <tr>
                         <td>Sum along columns</td>
                         <td><code>sum(A)</code></td>
+                        <td><code>sum(A,1)</code></td>
                         <td><code>np.sum(A, axis=0)</code></td>
                         <td><code>sum(A, dims=1)</code></td>
                     </tr>
                     <tr>
                         <td>Sum along rows</td>
+                        <td><code>sum(A, 2)</code></td>
                         <td><code>sum(A, 2)</code></td>
                         <td><code>np.sum(A, axis=1)</code></td>
                         <td><code>sum(A, dims=2)</code></td>
@@ -1021,29 +1135,34 @@ np.matmul(A, B)</code></td>
                     <tr>
                         <td>Cumulative sum</td>
                         <td><code>cumsum(A)</code></td>
+                        <td><code>cumsum(A)</code></td>
                         <td><code>np.cumsum(A)</code></td>
                         <td><code>cumsum(A)</code></td>
                     </tr>
                     <tr>
                         <td>Max of all elements</td>
                         <td><code>max(A(:))</code></td>
+                        <td><code>max(A)</code></td>
                         <td><code>np.max(A)</code></td>
                         <td><code>maximum(A)</code></td>
                     </tr>
                     <tr>
                         <td>Max along columns</td>
                         <td><code>max(A)</code></td>
+                        <td><code>max(A,1)</code></td>
                         <td><code>np.max(A, axis=0)</code></td>
                         <td><code>maximum(A, dims=1)</code></td>
                     </tr>
                     <tr>
                         <td>Max along rows</td>
                         <td><code>max(A, [], 2)</code></td>
+                        <td><code>max(A, 2)</code></td>
                         <td><code>np.max(A, axis=1)</code></td>
                         <td><code>maximum(A, dims=2)</code></td>
                     </tr>
                     <tr>
                         <td>Max and index</td>
+                        <td><code>[val, idx] = max(A)</code></td>
                         <td><code>[val, idx] = max(A)</code></td>
                         <td><code>idx = np.argmax(A)
 val = A.flat[idx]</code></td>
@@ -1052,23 +1171,27 @@ val = A.flat[idx]</code></td>
                     <tr>
                         <td>Min of all elements</td>
                         <td><code>min(A(:))</code></td>
+                        <td><code>min(A)</code></td>
                         <td><code>np.min(A)</code></td>
                         <td><code>minimum(A)</code></td>
                     </tr>
                     <tr>
                         <td>Min along columns</td>
                         <td><code>min(A)</code></td>
+                        <td><code>min(A,1)</code></td>
                         <td><code>np.min(A, axis=0)</code></td>
                         <td><code>minimum(A, dims=1)</code></td>
                     </tr>
                     <tr>
                         <td>Min along rows</td>
                         <td><code>min(A, [], 2)</code></td>
+                        <td><code>min(A, 2)</code></td>
                         <td><code>np.min(A, axis=1)</code></td>
                         <td><code>minimum(A, dims=2)</code></td>
                     </tr>
                     <tr>
                         <td>Min and index</td>
+                        <td><code>[val, idx] = min(A)</code></td>
                         <td><code>[val, idx] = min(A)</code></td>
                         <td><code>idx = np.argmin(A)
 val = A.flat[idx]</code></td>
@@ -1077,11 +1200,13 @@ val = A.flat[idx]</code></td>
                     <tr>
                         <td>Mean</td>
                         <td><code>mean(A)</code></td>
+                        <td><code>mean(A)</code></td>
                         <td><code>np.mean(A)</code></td>
                         <td><code>mean(A)</code></td>
                     </tr>
                     <tr>
                         <td>Median</td>
+                        <td><code>median(A)</code></td>
                         <td><code>median(A)</code></td>
                         <td><code>np.median(A)</code></td>
                         <td><code>median(A)</code></td>
@@ -1089,12 +1214,14 @@ val = A.flat[idx]</code></td>
                     <tr>
                         <td>Standard deviation</td>
                         <td><code>std(A)</code></td>
+                        <td><code>stdev(A)</code></td>
                         <td><code>np.std(A)</code></td>
                         <td><code>std(A)</code></td>
                     </tr>
                     <tr>
                         <td>Variance</td>
                         <td><code>var(A)</code></td>
+                        <td><code>variance(A)</code></td>
                         <td><code>np.var(A)</code></td>
                         <td><code>var(A)</code></td>
                     </tr>
@@ -1108,6 +1235,7 @@ val = A.flat[idx]</code></td>
                     <tr>
                         <th>Description</th>
                         <th>MATLAB</th>
+                        <th>Scilab</th>
                         <th>Python</th>
                         <th>Julia</th>
                     </tr>
@@ -1116,6 +1244,7 @@ val = A.flat[idx]</code></td>
                     <tr>
                         <td>Comment</td>
                         <td><code>% This is a comment</code></td>
+                        <td><code>// This is a comment</code></td>
                         <td><code># This is a comment</code></td>
                         <td><code># This is a comment</code></td>
                     </tr>
@@ -1125,6 +1254,10 @@ val = A.flat[idx]</code></td>
 This is a
 multiline comment
 %}</code></td>
+                        <td><code>/*
+This is a
+multiline comment
+*/</code></td>
                         <td><code>"""
 This is a
 multiline comment
@@ -1139,6 +1272,9 @@ multiline comment
                         <td><code>for i = 1:10
     disp(i)
 end</code></td>
+                        <td><code>for i = 1:10
+    disp(i)
+end</code></td>
                         <td><code>for i in range(1, 11):
     print(i)</code></td>
                         <td><code>for i in 1:10
@@ -1147,33 +1283,43 @@ end</code></td>
                     </tr>
                     <tr>
                         <td>While loop</td>
-                        <td><code>while x < 10
+                        <td><code>while x &lt; 10
     x = x + 1
 end</code></td>
-                        <td><code>while x < 10:
+                        <td><code>while x &lt; 10
+    x = x + 1
+end</code></td>
+                        <td><code>while x &lt; 10:
     x = x + 1</code></td>
-                        <td><code>while x < 10
+                        <td><code>while x &lt; 10
     x = x + 1
 end</code></td>
                     </tr>
                     <tr>
                         <td>If statement</td>
-                        <td><code>if x > 0
+                        <td><code>if x &gt; 0
     disp('positive')
-elseif x < 0
+elseif x &lt; 0
     disp('negative')
 else
     disp('zero')
 end</code></td>
-                        <td><code>if x > 0:
+                        <td><code>if x &gt; 0
+    disp('positive')
+elseif x &lt; 0
+    disp('negative')
+else
+    disp('zero')
+end</code></td>
+                        <td><code>if x &gt; 0:
     print('positive')
-elif x < 0:
+elif x &lt; 0:
     print('negative')
 else:
     print('zero')</code></td>
-                        <td><code>if x > 0
+                        <td><code>if x &gt; 0
     println("positive")
-elseif x < 0
+elseif x &lt; 0
     println("negative")
 else
     println("zero")
@@ -1181,6 +1327,9 @@ end</code></td>
                     </tr>
                     <tr>
                         <td>Function definition</td>
+                        <td><code>function y = f(x)
+    y = x^2;
+end</code></td>
                         <td><code>function y = f(x)
     y = x^2;
 end</code></td>
@@ -1195,8 +1344,9 @@ f(x) = x^2</code></td>
                     <tr>
                         <td>Anonymous function</td>
                         <td><code>f = @(x) x^2</code></td>
+                        <td><code>f = #(x)-&gt;(x^2)</code></td>
                         <td><code>f = lambda x: x**2</code></td>
-                        <td><code>f = x -> x^2</code></td>
+                        <td><code>f = x -&gt; x^2</code></td>
                     </tr>
                     <tr>
                         <td>Try-catch</td>
@@ -1204,6 +1354,11 @@ f(x) = x^2</code></td>
     % code
 catch ME
     disp(ME.message)
+end</code></td>
+                        <td><code>try
+    // code
+catch
+    disp(lasterror())
 end</code></td>
                         <td><code>try:
     # code
@@ -1219,12 +1374,15 @@ end</code></td>
                         <td>Print to console</td>
                         <td><code>disp('text')
 fprintf('text\n')</code></td>
+                        <td><code>disp('text')
+printf('text\n')</code></td>
                         <td><code>print('text')</code></td>
                         <td><code>println("text")
 print("text")</code></td>
                     </tr>
                     <tr>
                         <td>String formatting</td>
+                        <td><code>sprintf('x = %d', x)</code></td>
                         <td><code>sprintf('x = %d', x)</code></td>
                         <td><code>f'x = {x}'
 'x = {}'.format(x)</code></td>
@@ -1233,30 +1391,35 @@ print("text")</code></td>
                     </tr>
                     <tr>
                         <td>Ternary operator</td>
-                        <td><code>y = (x > 0) * 1 + (x <= 0) * (-1)</code></td>
-                        <td><code>y = 1 if x > 0 else -1</code></td>
-                        <td><code>y = x > 0 ? 1 : -1</code></td>
+                        <td><code>y = (x &gt; 0) * 1 + (x &lt;= 0) * (-1)</code></td>
+                        <td><code>y = (x &gt; 0) * 1 + (x &lt;= 0) * (-1)</code></td>
+                        <td><code>y = 1 if x &gt; 0 else -1</code></td>
+                        <td><code>y = x &gt; 0 ? 1 : -1</code></td>
                     </tr>
                     <tr>
                         <td>List comprehension</td>
                         <td><code>y = arrayfun(@(x) x^2, 1:10)</code></td>
+                        <td><code>y = feval(1:10, #(x)-&gt;(x^2))</code></td>
                         <td><code>y = [x**2 for x in range(1, 11)]</code></td>
                         <td><code>y = [x^2 for x in 1:10]</code></td>
                     </tr>
                     <tr>
                         <td>Map function</td>
                         <td><code>arrayfun(@(x) x^2, A)</code></td>
+                        <td><code>y = feval(A, #(x)-&gt;(x^2))</code></td>
                         <td><code>list(map(lambda x: x**2, A))</code></td>
-                        <td><code>map(x -> x^2, A)</code></td>
+                        <td><code>map(x -&gt; x^2, A)</code></td>
                     </tr>
                     <tr>
                         <td>Filter function</td>
-                        <td><code>A(A > 0)</code></td>
-                        <td><code>list(filter(lambda x: x > 0, A))</code></td>
-                        <td><code>filter(x -> x > 0, A)</code></td>
+                        <td><code>A(A &gt; 0)</code></td>
+                        <td><code>A(A &gt; 0)</code></td>
+                        <td><code>list(filter(lambda x: x &gt; 0, A))</code></td>
+                        <td><code>filter(x -&gt; x &gt; 0, A)</code></td>
                     </tr>
                     <tr>
                         <td>Type checking</td>
+                        <td><code>isa(x, 'double')</code></td>
                         <td><code>isa(x, 'double')</code></td>
                         <td><code>isinstance(x, float)</code></td>
                         <td><code>isa(x, Float64)</code></td>
@@ -1264,6 +1427,8 @@ print("text")</code></td>
                     <tr>
                         <td>Tuples</td>
                         <td><code>% Cell arrays serve similar purpose
+A = {1, 'text', [1 2 3]}</code></td>
+                        <td><code>// Cell arrays serve similar purpose
 A = {1, 'text', [1 2 3]}</code></td>
                         <td><code>t = (1, 'text', [1, 2, 3])
 # Named tuple
@@ -1286,21 +1451,26 @@ a, b, c = t</code></td>
     end
     f = @mult;
 end</code></td>
+                        <td><code>function f = makemultiplier(x)
+    f = #(y) -&gt; (x*y)
+end
+</code></td>
                         <td><code>def make_multiplier(x):
     def mult(y):
         return x * y
     return mult</code></td>
                         <td><code>function make_multiplier(x)
-    return y -> x * y
+    return y -&gt; x * y
 end
 # Or with mutable state
 function counter()
     count = 0
-    return () -> (count += 1)
+    return () -&gt; (count += 1)
 end</code></td>
                     </tr>
                     <tr>
                         <td>In-place modification</td>
+                        <td><code>A(:) = B(:)</code></td>
                         <td><code>A(:) = B(:)</code></td>
                         <td><code>A[:] = B[:]</code></td>
                         <td><code># Convention: ! indicates mutation
@@ -1324,6 +1494,7 @@ A .+= 1  # Add 1 to all elements</code></td>
                     <tr>
                         <td>Timing code</td>
                         <td><code>tic; % code; toc</code></td>
+                        <td><code>tic; // code; toc</code></td>
                         <td><code>import time
 start = time.time()
 # code
@@ -1344,6 +1515,7 @@ end</code></td>
                     <tr>
                         <th>Description</th>
                         <th>MATLAB</th>
+                        <th>Scilab</th>
                         <th>Python</th>
                         <th>Julia</th>
                     </tr>
@@ -1352,6 +1524,7 @@ end</code></td>
                     <tr>
                         <td>Define ODE</td>
                         <td><code>f = @(t,y) -2*y + sin(t)</code></td>
+                        <td><code>f = #(t,y) -&gt; (-2*y + sin(t))</code></td>
                         <td><code>def f(t, y):
     return -2*y + np.sin(t)</code></td>
                         <td><code>f(u, p, t) = -2*u + sin(t)</code></td>
@@ -1359,6 +1532,7 @@ end</code></td>
                     <tr>
                         <td>Solve ODE</td>
                         <td><code>[t, y] = ode45(f, [0, 10], 1)</code></td>
+                        <td><code>[t, y] = cvode(f, [0, 10], 1)</code></td>
                         <td><code>from scipy.integrate import solve_ivp
 sol = solve_ivp(f, [0, 10], [1])</code></td>
                         <td><code>prob = ODEProblem(f, 1.0, (0.0, 10.0))
@@ -1368,6 +1542,8 @@ sol = solve(prob)</code></td>
                         <td>Specify time points</td>
                         <td><code>tspan = 0:0.1:10;
 [t, y] = ode45(f, tspan, 1)</code></td>
+                        <td><code>tspan = 0:0.1:10;
+[t, y] = cvode(f, tspan, 1)</code></td>
                         <td><code>t_eval = np.linspace(0, 10, 101)
 sol = solve_ivp(f, [0, 10], [1],
                 t_eval=t_eval)</code></td>
@@ -1386,6 +1562,7 @@ sol = solve(prob, saveat=t_save)</code></td>
                     <tr>
                         <th>Description</th>
                         <th>MATLAB</th>
+                        <th>Scilab</th>
                         <th>Python</th>
                         <th>Julia</th>
                     </tr>
@@ -1393,6 +1570,11 @@ sol = solve(prob, saveat=t_save)</code></td>
                 <tbody>
                     <tr>
                         <td>Define system</td>
+                        <td><code>function dydt = mysys(t, y)
+    dydt = zeros(2,1);
+    dydt(1) = y(2);
+    dydt(2) = -y(1) - 0.1*y(2);
+end</code></td>
                         <td><code>function dydt = mysys(t, y)
     dydt = zeros(2,1);
     dydt(1) = y(2);
@@ -1409,6 +1591,7 @@ end</code></td>
                     <tr>
                         <td>Solve system</td>
                         <td><code>[t, y] = ode45(@mysys, [0, 20], [1; 0])</code></td>
+                        <td><code>[t, y] = cvode(mysys, [0, 20], [1; 0])</code></td>
                         <td><code>sol = solve_ivp(mysys, [0, 20], [1, 0])</code></td>
                         <td><code>u0 = [1.0, 0.0]
 tspan = (0.0, 20.0)
@@ -1418,6 +1601,8 @@ sol = solve(prob)</code></td>
                     <tr>
                         <td>Stiff solver</td>
                         <td><code>[t, y] = ode15s(@mysys, [0, 20], [1; 0])</code></td>
+                        <td><code>[t, y] = cvode(mysys, [0, 20], [1; 0], ...
+               method="BDF")</code></td>
                         <td><code>sol = solve_ivp(mysys, [0, 20], [1, 0],
                 method='BDF')</code></td>
                         <td><code>sol = solve(prob, FBDF())</code></td>
@@ -1431,6 +1616,7 @@ sol = solve(prob)</code></td>
                     <tr>
                         <th>Description</th>
                         <th>MATLAB</th>
+                        <th>Scilab</th>
                         <th>Python</th>
                         <th>Julia</th>
                     </tr>
@@ -1439,6 +1625,15 @@ sol = solve(prob)</code></td>
                     <tr>
                         <td>Define mass matrix DAE</td>
                         <td><code>% ROBER DAE problem
+M = [1 0 0; 0 1 0; 0 0 0];
+
+function dydt = rober(t, y)
+    k1 = 0.04; k2 = 3e7; k3 = 1e4;
+    dydt = [-k1*y(1) + k3*y(2)*y(3);
+            k1*y(1) - k2*y(2)^2 - k3*y(2)*y(3);
+            y(1) + y(2) + y(3) - 1];
+end</code></td>
+                        <td><code>// ROBER DAE problem
 M = [1 0 0; 0 1 0; 0 0 0];
 
 function dydt = rober(t, y)
@@ -1477,6 +1672,10 @@ prob = ODEProblem(f_ode, u0, tspan, p)</code></td>
                   'MStateDependence', 'none');
 y0 = [1; 0; 0];
 [t, y] = ode15s(@rober, [0 1e-5], y0, options)</code></td>
+                        <td><code>
+y0 = [1; 0; 0];
+[t,y,info] = ida(#(t,y,yp)-&gt;(M*yp-rober(t, y, yp)), ...
+    [0 1e-5], y0, [0;0;0], calcIc="y0yp0"); </code></td>
                         <td><code># Not possible in SciPy</code></td>
                         <td><code>sol = solve(prob, Rodas5())
 # Automatically detects DAE and uses
@@ -1491,6 +1690,7 @@ y0 = [1; 0; 0];
                     <tr>
                         <th>Description</th>
                         <th>MATLAB</th>
+                        <th>Scilab</th>
                         <th>Python</th>
                         <th>Julia</th>
                     </tr>
@@ -1500,6 +1700,12 @@ y0 = [1; 0; 0];
                         <td>Define implicit DAE</td>
                         <td><code>function res = implicitdae(t, y, yp)
     % Residual form: res = f(t,y,y') = 0
+    res = [yp(1) - y(2);
+           yp(2) + 9.81 + y(3)*y(1);
+           y(1)^2 + y(2)^2 - 1];
+end</code></td>
+                        <td><code>function res = implicitdae(t, y, yp)
+    // Residual form: res = f(t,y,y') = 0
     res = [yp(1) - y(2);
            yp(2) + 9.81 + y(3)*y(1);
            y(1)^2 + y(2)^2 - 1];
@@ -1524,6 +1730,9 @@ prob = DAEProblem(residual!, du0, u0, tspan,
                         <td><code>[y0, yp0] = decic(@implicitdae, 0, ...
                   guess_y, [], guess_yp, []);
 [t, y] = ode15i(@implicitdae, [0 10], y0, yp0)</code></td>
+                        <td><code>
+[t, y] = ida(implicitdae, [0 10], guess_y, ...
+             guess_yp, calcIc="y0yp0")</code></td>
                         <td><code># Would require Assimulo installation
 # and IDA solver setup</code></td>
                         <td><code>using Sundials
@@ -1542,6 +1751,7 @@ sol = solve(prob, IDA())
                     <tr>
                         <th>Description</th>
                         <th>MATLAB</th>
+                        <th>Scilab</th>
                         <th>Python</th>
                         <th>Julia</th>
                     </tr>
@@ -1551,6 +1761,8 @@ sol = solve(prob, IDA())
                         <td>Find root</td>
                         <td><code>f = @(x) x^3 - 2*x - 5;
 x = fzero(f, 2)</code></td>
+                        <td><code>f = #(x) -&gt; (x^3 - 2*x - 5);
+x = fsolve(2, f)</code></td>
                         <td><code>from scipy.optimize import fsolve
 f = lambda x: x**3 - 2*x - 5
 x = fsolve(f, 2)</code></td>
@@ -1564,6 +1776,9 @@ sol = solve(prob)</code></td>
                         <td><code>f = @(x) x^3 - 2*x - 5;
 df = @(x) 3*x^2 - 2;
 x = fzero(@(x) [f(x), df(x)], 2)</code></td>
+                        <td><code>f = #(x) -&gt; (x^3 - 2*x - 5);
+df = #(x) -> (3*x^2 - 2);
+x = fsolve(2, f, df)</code></td>
                         <td><code>from scipy.optimize import newton
 f = lambda x: x**3 - 2*x - 5
 df = lambda x: 3*x**2 - 2
@@ -1582,6 +1797,7 @@ sol = solve(prob, NewtonRaphson())</code></td>
                     <tr>
                         <th>Description</th>
                         <th>MATLAB</th>
+                        <th>Scilab</th>
                         <th>Python</th>
                         <th>Julia</th>
                     </tr>
@@ -1589,6 +1805,10 @@ sol = solve(prob, NewtonRaphson())</code></td>
                 <tbody>
                     <tr>
                         <td>Define system</td>
+                        <td><code>function F = mysys(x)
+    F = [x(1)^2 + x(2)^2 - 1;
+         x(1) - x(2)^2];
+end</code></td>
                         <td><code>function F = mysys(x)
     F = [x(1)^2 + x(2)^2 - 1;
          x(1) - x(2)^2];
@@ -1605,6 +1825,8 @@ end</code></td>
                         <td>Solve</td>
                         <td><code>x0 = [1; 1];
 x = fsolve(@mysys, x0)</code></td>
+                        <td><code>x0 = [1; 1];
+x = fsolve(x0, mysys)</code></td>
                         <td><code>x0 = [1, 1]
 x = fsolve(mysys, x0)</code></td>
                         <td><code>using NonlinearSolve
@@ -1626,7 +1848,9 @@ sol = solve(prob)</code></td>
                     <li>PyTorch optimizers (torch.optim) - Different API and tensor requirements</li>
                     <li>CasADi optimization - Must use CasADi's own solvers</li>
                 </ul>
-                <p style="margin-top: 10px;">For gradient-based optimization with autodiff, PyTorch requires using torch.optim optimizers (Adam, SGD, etc.) with tensor inputs.</p>
+                <p style="margin-top: 10px;">For gradient-based 
+optimization with autodiff, PyTorch requires using torch.optim 
+optimizers (Adam, SGD, etc.) with tensor inputs.</p>
             </div>
 
             <h3>Unconstrained</h3>
@@ -1635,6 +1859,7 @@ sol = solve(prob)</code></td>
                     <tr>
                         <th>Description</th>
                         <th>MATLAB</th>
+                        <th>Scilab</th>
                         <th>Python</th>
                         <th>Julia</th>
                     </tr>
@@ -1644,6 +1869,8 @@ sol = solve(prob)</code></td>
                         <td>Minimize scalar</td>
                         <td><code>f = @(x) (x-2)^2 + 3;
 x = fminbnd(f, 0, 5)</code></td>
+                        <td><code>f = #(x) -&gt; ((x-2)^2 + 3);
+[_,x] = optim(list(NDcost,f), 'b', 0, 5, 2.5)</code></td>
                         <td><code>from scipy.optimize import minimize_scalar
 f = lambda x: (x-2)**2 + 3
 res = minimize_scalar(f, bounds=(0, 5),
@@ -1656,6 +1883,9 @@ sol = solve(prob)</code></td>
                     <tr>
                         <td>Minimize multivariate</td>
                         <td><code>f = @(x) x(1)^2 + x(2)^2;
+x0 = [0; 0];
+x = fminsearch(f, x0)</code></td>
+                        <td><code>f = #(x) -&gt; (x(1)^2 + x(2)^2);
 x0 = [0; 0];
 x = fminsearch(f, x0)</code></td>
                         <td><code>from scipy.optimize import minimize
@@ -1672,6 +1902,11 @@ sol = solve(prob, Optim.LBFGS())</code></td>
                        'GradObj','on');
 x = fminunc(@(x) deal(f(x), grad(x)),
             x0, options)</code></td>
+                        <td><code>function [f, g, ind] = costgrad(x, ind)
+    f = x(1)^2 + x(2)^2;
+    g = 2*[x(1) ;x(2)];
+end
+[_,x] = optim(costgrad, x0)</code></td>
                         <td><code>def grad(x):
     return np.array([2*x[0], 2*x[1]])
 res = minimize(f, x0, jac=grad)</code></td>
@@ -1690,6 +1925,7 @@ sol = solve(prob, Optim.LBFGS())</code></td>
                     <tr>
                         <th>Description</th>
                         <th>MATLAB</th>
+                        <th>Scilab</th>
                         <th>Python</th>
                         <th>Julia</th>
                     </tr>
@@ -1698,6 +1934,10 @@ sol = solve(prob, Optim.LBFGS())</code></td>
                     <tr>
                         <td>Box constraints</td>
                         <td><code>lb = [0; 0]; ub = [1; 1];
+x = fmincon(f, x0, [], [], [], [], lb, ub)</code></td>
+                        <td><code>atomsInstall fmincon
+atomsLoad fmincon         
+lb = [0; 0]; ub = [1; 1];
 x = fmincon(f, x0, [], [], [], [], lb, ub)</code></td>
                         <td><code>bounds = [(0, 1), (0, 1)]
 res = minimize(f, x0, bounds=bounds)</code></td>
@@ -1715,6 +1955,7 @@ sol = solve(prob)</code></td>
                     <tr>
                         <th>Description</th>
                         <th>MATLAB</th>
+                        <th>Scilab</th>
                         <th>Python</th>
                         <th>Julia</th>
                     </tr>
@@ -1722,6 +1963,10 @@ sol = solve(prob)</code></td>
                 <tbody>
                     <tr>
                         <td>Linear interpolation</td>
+                        <td><code>x = [1, 2, 3, 4, 5];
+y = [2, 4, 1, 3, 5];
+xi = 1:0.1:5;
+yi = interp1(x, y, xi, 'linear')</code></td>
                         <td><code>x = [1, 2, 3, 4, 5];
 y = [2, 4, 1, 3, 5];
 xi = 1:0.1:5;
@@ -1738,6 +1983,7 @@ yi = itp.(xi)</code></td>
                     <tr>
                         <td>Cubic spline</td>
                         <td><code>yi = interp1(x, y, xi, 'spline')</code></td>
+                        <td><code>yi = interp1(x, y, xi, 'spline')</code></td>
                         <td><code>f = interpolate.interp1d(x, y, kind='cubic')
 yi = f(xi)</code></td>
                         <td><code>itp = CubicSpline(y, x)
@@ -1745,6 +1991,8 @@ yi = itp.(xi)</code></td>
                     </tr>
                     <tr>
                         <td>Polynomial fit</td>
+                        <td><code>p = polyfit(x, y, 2);
+yfit = polyval(p, x)</code></td>
                         <td><code>p = polyfit(x, y, 2);
 yfit = polyval(p, x)</code></td>
                         <td><code>p = np.polyfit(x, y, 2)
@@ -1758,6 +2006,11 @@ yfit = p.(x)</code></td>
                         <td><code>model = @(b,x) b(1)*exp(b(2)*x);
 b0 = [1, 0.1];
 b = lsqcurvefit(model, b0, x, y)</code></td>
+                        <td><code>function resid = model(b,xy)
+    pred = b(1)*exp(b(2)*xy(1,:));
+    resid = xy(2,:)-pred;
+end
+b = datafit(model, [x;y], b0)</code></td>
                         <td><code>from scipy.optimize import curve_fit
 def model(x, a, b):
     return a * np.exp(b * x)
@@ -1780,6 +2033,7 @@ sol = solve(prob)</code></td>
                     <tr>
                         <th>Description</th>
                         <th>MATLAB</th>
+                        <th>Scilab</th>
                         <th>Python</th>
                         <th>Julia</th>
                     </tr>
@@ -1789,6 +2043,8 @@ sol = solve(prob)</code></td>
                         <td>1D integration</td>
                         <td><code>f = @(x) exp(-x.^2);
 I = integral(f, 0, 1)</code></td>
+                        <td><code>f = #(x) -&gt; exp(-x.^2);
+I = intg(0, 1, f)</code></td>
                         <td><code>from scipy import integrate
 f = lambda x: np.exp(-x**2)
 I, err = integrate.quad(f, 0, 1)</code></td>
@@ -1802,6 +2058,8 @@ I = sol.u</code></td>
                         <td>2D integration</td>
                         <td><code>f = @(x,y) exp(-x.^2 - y.^2);
 I = integral2(f, 0, 1, 0, 1)</code></td>
+                        <td><code>f = #(x,y) -&gt; (exp(-x.^2 - y.^2));
+I = int2d(0, 1, 0, 1, f)</code></td>
                         <td><code>f = lambda y, x: np.exp(-x**2 - y**2)
 I, err = integrate.dblquad(f, 0, 1, 0, 1)</code></td>
                         <td><code>using Integrals
@@ -1815,6 +2073,9 @@ I = sol.u</code></td>
                         <td><code>x = linspace(0, 1, 100);
 y = exp(-x.^2);
 I = trapz(x, y)</code></td>
+                        <td><code>x = linspace(0, 1, 100);
+y = exp(-x.^2);
+I = inttrap(x, y)</code></td>
                         <td><code>x = np.linspace(0, 1, 100)
 y = np.exp(-x**2)
 I = np.trapz(y, x)</code></td>
@@ -1834,6 +2095,7 @@ I = DataInterpolations.integral(itp, first(x), last(x))</code></td>
                     <tr>
                         <th>Description</th>
                         <th>MATLAB</th>
+                        <th>Scilab</th>
                         <th>Python</th>
                         <th>Julia</th>
                     </tr>
@@ -1841,6 +2103,8 @@ I = DataInterpolations.integral(itp, first(x), last(x))</code></td>
                 <tbody>
                     <tr>
                         <td>FFT</td>
+                        <td><code>y = fft(x);
+freq = (0:length(x)-1)*fs/length(x);</code></td>
                         <td><code>y = fft(x);
 freq = (0:length(x)-1)*fs/length(x);</code></td>
                         <td><code>y = np.fft.fft(x)
@@ -1852,12 +2116,14 @@ freq = fftfreq(length(x), fs)</code></td>
                     <tr>
                         <td>Inverse FFT</td>
                         <td><code>x = ifft(y)</code></td>
+                        <td><code>x = ifft(y)</code></td>
                         <td><code>x = np.fft.ifft(y)</code></td>
                         <td><code>x = ifft(y)</code></td>
                     </tr>
                     <tr>
                         <td>Power spectrum</td>
                         <td><code>[pxx, f] = pwelch(x, [], [], [], fs)</code></td>
+                        <td><code>pxx = pspect(sec_step, sec_leng, wtype, x)</code></td>
                         <td><code>from scipy import signal
 f, pxx = signal.welch(x, fs)</code></td>
                         <td><code>using DSP
@@ -1867,6 +2133,8 @@ pxx = welch_pgram(x, fs=fs)</code></td>
                         <td>Filter (lowpass)</td>
                         <td><code>[b, a] = butter(4, 0.2);
 y = filter(b, a, x)</code></td>
+                        <td><code>H = iir(4,"lp","butt",0.2,[]);
+y = filter(H.num, H.den, x)</code></td>
                         <td><code>b, a = signal.butter(4, 0.2)
 y = signal.filtfilt(b, a, x)</code></td>
                         <td><code>using DSP
@@ -1875,6 +2143,7 @@ y = filt(H, x)</code></td>
                     </tr>
                     <tr>
                         <td>Convolution</td>
+                        <td><code>y = conv(x, h)</code></td>
                         <td><code>y = conv(x, h)</code></td>
                         <td><code>y = np.convolve(x, h)</code></td>
                         <td><code>y = conv(x, h)</code></td>
@@ -1891,6 +2160,7 @@ y = filt(H, x)</code></td>
                     <tr>
                         <th>Description</th>
                         <th>MATLAB</th>
+                        <th>Scilab</th>
                         <th>Python</th>
                         <th>Julia</th>
                     </tr>
@@ -1900,6 +2170,8 @@ y = filt(H, x)</code></td>
                         <td>Mean, std</td>
                         <td><code>m = mean(x);
 s = std(x);</code></td>
+                        <td><code>m = mean(x);
+s = stdev(x);</code></td>
                         <td><code>m = np.mean(x)
 s = np.std(x)</code></td>
                         <td><code>using Statistics
@@ -1910,6 +2182,8 @@ s = std(x)</code></td>
                         <td>Median, quantiles</td>
                         <td><code>med = median(x);
 q = quantile(x, [0.25, 0.75]);</code></td>
+                        <td><code>med = median(x);
+q = perctl(x, [25, 75]);</code></td>
                         <td><code>med = np.median(x)
 q = np.quantile(x, [0.25, 0.75])</code></td>
                         <td><code>med = median(x)
@@ -1918,6 +2192,7 @@ q = quantile(x, [0.25, 0.75])</code></td>
                     <tr>
                         <td>Correlation</td>
                         <td><code>R = corrcoef(x, y)</code></td>
+                        <td><code>R = correl(x, y)</code></td>
                         <td><code>R = np.corrcoef(x, y)</code></td>
                         <td><code>R = cor(x, y)</code></td>
                     </tr>
@@ -1930,6 +2205,7 @@ q = quantile(x, [0.25, 0.75])</code></td>
                     <tr>
                         <th>Description</th>
                         <th>MATLAB</th>
+                        <th>Scilab</th>
                         <th>Python</th>
                         <th>Julia</th>
                     </tr>
@@ -1940,6 +2216,9 @@ q = quantile(x, [0.25, 0.75])</code></td>
                         <td><code>x = randn(100, 1);
 y = normrnd(mu, sigma, [100, 1]);
 p = normpdf(x, mu, sigma);</code></td>
+                        <td><code>x = rand(100, 1, "normal");
+y = grand(100, 1, "nor", mu, sigma);
+</code></td>
                         <td><code>from scipy import stats
 x = np.random.randn(100)
 y = np.random.normal(mu, sigma, 100)
@@ -1953,6 +2232,8 @@ p = pdf(d, x)</code></td>
                         <td>Uniform</td>
                         <td><code>x = rand(100, 1);
 y = unifrnd(a, b, [100, 1]);</code></td>
+                        <td><code>x = rand(100, 1);
+y = grand(100, 1, "unf", a, b);</code></td>
                         <td><code>x = np.random.rand(100)
 y = np.random.uniform(a, b, 100)</code></td>
                         <td><code>d = Uniform(a, b)
@@ -1962,6 +2243,7 @@ x = rand(d, 100)</code></td>
                         <td>Fit to data</td>
                         <td><code>pd = fitdist(x, 'Normal');
 params = pd.ParameterValues;</code></td>
+                        <td><code>// Not available natively</code></td>
                         <td><code>params = stats.norm.fit(x)</code></td>
                         <td><code>d = fit(Normal, x)</code></td>
                     </tr>
@@ -1977,6 +2259,7 @@ params = pd.ParameterValues;</code></td>
                     <tr>
                         <th>Description</th>
                         <th>MATLAB</th>
+                        <th>Scilab</th>
                         <th>Python</th>
                         <th>Julia</th>
                     </tr>
@@ -1993,6 +2276,17 @@ D2 = gallery('tridiag', nx, 1, -2, 1)/dx^2;
 alpha = 0.01;
 f = @(t,u) alpha*D2*u;
 [t, u] = ode45(f, [0, 1], sin(pi*x));</code></td>
+                        <td><code>// Spatial discretization
+nx = 50; dx = 1/(nx-1);
+x = linspace(0, 1, nx)';
+D2 = (diag(ones(nx-1,1), 1) - ...
+      2*diag(ones(nx,1)) + ...
+      diag(ones(nx-1,1), -1))/dx^2;
+
+// Time integration
+alpha = 0.01;
+f = #(t,u) -&gt; (alpha*D2*u);
+[t, u] = cvode(f, [0, 1], sin(pi*x));</code></td>
                         <td><code># Spatial discretization
 nx = 50
 x = np.linspace(0, 1, nx)
@@ -2042,6 +2336,7 @@ sol = solve(prob)</code></td>
                     <tr>
                         <th>Description</th>
                         <th>MATLAB</th>
+                        <th>Scilab</th>
                         <th>Python</th>
                         <th>Julia</th>
                     </tr>
@@ -2050,6 +2345,7 @@ sol = solve(prob)</code></td>
                     <tr>
                         <td>Define symbols</td>
                         <td><code>syms x y z</code></td>
+                        <td><code>// Not available natively</code></td>
                         <td><code>import sympy as sp
 x, y, z = sp.symbols('x y z')</code></td>
                         <td><code>using Symbolics
@@ -2058,30 +2354,35 @@ x, y, z = sp.symbols('x y z')</code></td>
                     <tr>
                         <td>Create expression</td>
                         <td><code>expr = x^2 + 2*x*y + y^2</code></td>
+                        <td><code>// Not available natively</code></td>
                         <td><code>expr = x**2 + 2*x*y + y**2</code></td>
                         <td><code>expr = x^2 + 2*x*y + y^2</code></td>
                     </tr>
                     <tr>
                         <td>Substitute values</td>
                         <td><code>subs(expr, x, 2)</code></td>
+                        <td><code>// Not available natively</code></td>
                         <td><code>expr.subs(x, 2)</code></td>
-                        <td><code>substitute(expr, x => 2)</code></td>
+                        <td><code>substitute(expr, x =&gt; 2)</code></td>
                     </tr>
                     <tr>
                         <td>Simplify</td>
                         <td><code>simplify(expr)</code></td>
+                        <td><code>// Not available natively</code></td>
                         <td><code>sp.simplify(expr)</code></td>
                         <td><code>simplify(expr)</code></td>
                     </tr>
                     <tr>
                         <td>Expand</td>
                         <td><code>expand(expr)</code></td>
+                        <td><code>// Not available natively</code></td>
                         <td><code>sp.expand(expr)</code></td>
                         <td><code>expand(expr)</code></td>
                     </tr>
                     <tr>
                         <td>Factor</td>
                         <td><code>factor(expr)</code></td>
+                        <td><code>// Not available natively</code></td>
                         <td><code>sp.factor(expr)</code></td>
                         <td><code>using SymbolicUtils
 SymbolicUtils.simplify(expr)</code></td>
@@ -2089,6 +2390,7 @@ SymbolicUtils.simplify(expr)</code></td>
                     <tr>
                         <td>Generate function (out-of-place)</td>
                         <td><code>matlabFunction(expr, 'Vars', [x, y])</code></td>
+                        <td><code>// Not available natively</code></td>
                         <td><code>f = sp.lambdify([x, y], expr)</code></td>
                         <td><code>f = build_function(expr, [x, y])
 f_expr = eval(f[1])</code></td>
@@ -2096,6 +2398,7 @@ f_expr = eval(f[1])</code></td>
                     <tr>
                         <td>Generate function (in-place)</td>
                         <td><code>% Not available natively</code></td>
+                        <td><code>// Not available natively</code></td>
                         <td><code># Not available in SymPy</code></td>
                         <td><code>f = build_function(expr, [x, y])
 f! = eval(f[2])  # mutating version</code></td>
@@ -2103,6 +2406,7 @@ f! = eval(f[2])  # mutating version</code></td>
                     <tr>
                         <td>Symbolic in numerical solver</td>
                         <td><code>% Not compatible with ODE solvers</code></td>
+                        <td><code>// Not available natively</code></td>
                         <td><code># Not compatible with scipy.integrate</code></td>
                         <td><code># Can use symbolic parameters in ODE solvers
 using DifferentialEquations, Symbolics
@@ -2113,9 +2417,9 @@ eqs = [D(x) ~ a*x + b]
 sys = complete(sys)
 
 # Solve with symbolic parameters
-u0 = [x => 1.0]
+u0 = [x =&gt; 1.0]
 tspan = (0.0, 1.0)
-p = [a => -2.0, b => 1.0]
+p = [a =&gt; -2.0, b =&gt; 1.0]
 prob = ODEProblem(sys, u0, tspan, p)
 sol = solve(prob, Euler(), dt=0.25, adaptive=false)</code></td>
                     </tr>
@@ -2128,6 +2432,7 @@ sol = solve(prob, Euler(), dt=0.25, adaptive=false)</code></td>
                     <tr>
                         <th>Description</th>
                         <th>MATLAB</th>
+                        <th>Scilab</th>
                         <th>Python</th>
                         <th>Julia</th>
                     </tr>
@@ -2136,6 +2441,7 @@ sol = solve(prob, Euler(), dt=0.25, adaptive=false)</code></td>
                     <tr>
                         <td>Derivative</td>
                         <td><code>diff(expr, x)</code></td>
+                        <td><code>// Not available natively</code></td>
                         <td><code>sp.diff(expr, x)</code></td>
                         <td><code>D = Differential(x)
 expand_derivatives(D(expr))</code></td>
@@ -2143,6 +2449,7 @@ expand_derivatives(D(expr))</code></td>
                     <tr>
                         <td>Partial derivative</td>
                         <td><code>diff(expr, x, 2)</code></td>
+                        <td><code>// Not available natively</code></td>
                         <td><code>sp.diff(expr, x, 2)</code></td>
                         <td><code>D = Differential(x)
 expand_derivatives(D^2(expr))</code></td>
@@ -2150,18 +2457,21 @@ expand_derivatives(D^2(expr))</code></td>
                     <tr>
                         <td>Gradient</td>
                         <td><code>gradient(f, [x, y, z])</code></td>
+                        <td><code>// Not available natively</code></td>
                         <td><code>[sp.diff(f, var) for var in [x, y, z]]</code></td>
                         <td><code>Symbolics.gradient(f, [x, y, z])</code></td>
                     </tr>
                     <tr>
                         <td>Jacobian</td>
                         <td><code>jacobian([f1; f2], [x, y])</code></td>
+                        <td><code>// Not available natively</code></td>
                         <td><code>sp.Matrix([f1, f2]).jacobian([x, y])</code></td>
                         <td><code>Symbolics.jacobian([f1, f2], [x, y])</code></td>
                     </tr>
                     <tr>
                         <td>Integral (indefinite)</td>
                         <td><code>int(expr, x)</code></td>
+                        <td><code>// Not available natively</code></td>
                         <td><code>sp.integrate(expr, x)</code></td>
                         <td><code>using SymbolicIntegration
 symbolic_integrate(expr, x)</code></td>
@@ -2169,10 +2479,11 @@ symbolic_integrate(expr, x)</code></td>
                     <tr>
                         <td>Integral (definite)</td>
                         <td><code>int(expr, x, a, b)</code></td>
+                        <td><code>// Not available natively</code></td>
                         <td><code>sp.integrate(expr, (x, a, b))</code></td>
                         <td><code>using Integrals, Symbolics
 f = build_function(expr, x)
-prob = IntegralProblem((u,p) -> f[1](u), (a, b))
+prob = IntegralProblem((u,p) -&gt; f[1](u), (a, b))
 solve(prob, QuadGKJL())</code></td>
                     </tr>
                 </tbody>
@@ -2184,6 +2495,7 @@ solve(prob, QuadGKJL())</code></td>
                     <tr>
                         <th>Description</th>
                         <th>MATLAB</th>
+                        <th>Scilab</th>
                         <th>Python</th>
                         <th>Julia</th>
                     </tr>
@@ -2192,6 +2504,7 @@ solve(prob, QuadGKJL())</code></td>
                     <tr>
                         <td>Solve equation</td>
                         <td><code>solve(x^2 - 4 == 0, x)</code></td>
+                        <td><code>// Not available natively</code></td>
                         <td><code>sp.solve(x**2 - 4, x)</code></td>
                         <td><code>using Symbolics
 symbolic_solve(x^2 - 4, x)</code></td>
@@ -2199,6 +2512,7 @@ symbolic_solve(x^2 - 4, x)</code></td>
                     <tr>
                         <td>Solve system</td>
                         <td><code>solve([x + y == 5, x - y == 1], [x, y])</code></td>
+                        <td><code>// Not available natively</code></td>
                         <td><code>sp.solve([x + y - 5, x - y - 1], [x, y])</code></td>
                         <td><code>using Symbolics
 symbolic_solve([x + y ~ 5, x - y ~ 1], [x, y])</code></td>
@@ -2225,6 +2539,7 @@ symbolic_solve([x + y ~ 5, x - y ~ 1], [x, y])</code></td>
                     <tr>
                         <th>Description</th>
                         <th>MATLAB</th>
+                        <th>Scilab</th>
                         <th>Python</th>
                         <th>Julia</th>
                     </tr>
@@ -2233,6 +2548,8 @@ symbolic_solve([x + y ~ 5, x - y ~ 1], [x, y])</code></td>
                     <tr>
                         <td>Setup</td>
                         <td><code>% Not available natively</code></td>
+                        <td><code>atomsInstall diffcode
+atomsLoad diffcode</code></td>
                         <td><code>import torch</code></td>
                         <td><code>using ForwardDiff</code></td>
                     </tr>
@@ -2240,6 +2557,11 @@ symbolic_solve([x + y ~ 5, x - y ~ 1], [x, y])</code></td>
                         <td>Gradient (scalar → scalar)</td>
                         <td><code>% Not available natively
 % Use symbolic or finite differences</code></td>
+                        <td><code>
+f = #(x) -&gt; (x^2+sin(x))
+df = f(diffcode_der(2,1)).dv
+</code></td>
+
                         <td><code>from torch.autograd.functional import jvp
 
 def f(x):
@@ -2254,6 +2576,9 @@ df = ForwardDiff.derivative(f, 2.0)</code></td>
                     <tr>
                         <td>Gradient (vector → scalar)</td>
                         <td><code>% Not available natively</code></td>
+                        <td><code>f = #(x)->(sum(x.^2))
+grad = diffcode_jacobian(f,[1 2])
+                        </code></td>
                         <td><code>from torch.autograd.functional import jvp
 
 def f(x):
@@ -2274,6 +2599,9 @@ grad = ForwardDiff.gradient(f, [1.0, 2.0])</code></td>
                     <tr>
                         <td>Jacobian</td>
                         <td><code>% Not available natively</code></td>
+                        <td><code>f = #(x) -&gt; ( [x(1)^2; x(1)*x(2)] )
+diffcode_jacobian(f,[1 2])
+                        </code></td>
                         <td><code>from torch.autograd.functional import jacobian
 
 def f(x):
@@ -2287,6 +2615,9 @@ jac = ForwardDiff.jacobian(f, [1.0, 2.0])</code></td>
                     <tr>
                         <td>Hessian</td>
                         <td><code>% Not available natively</code></td>
+                        <td><code>f = #(x) -&gt; (sum(x.^2))
+diffcode_hessian(f,[1 2])
+                        </code></td>
                         <td><code>from torch.autograd.functional import hessian
 
 def f(x):
@@ -2299,6 +2630,12 @@ hess = hessian(f, x)</code></td>
                     <tr>
                         <td>Dual numbers</td>
                         <td><code>% Not available natively</code></td>
+                        <td><code>
+x = diffcode_der(2,1)
+y = x^2 + sin(x)
+// value: y.v
+// derivative : y.dv
+</code></td>
                         <td><code># Not exposed</code></td>
                         <td><code>using ForwardDiff
 x = ForwardDiff.Dual(2.0, 1.0)
@@ -2309,6 +2646,7 @@ y = x^2 + sin(x)
                     <tr>
                         <td>Consistency requirements</td>
                         <td><code>% N/A</code></td>
+                        <td><code>// N/A</code></td>
                         <td><code># Must replace ALL NumPy/SciPy calls:
 # np.sin → torch.sin
 # scipy.integrate → not compatible
@@ -2328,6 +2666,7 @@ y = x^2 + sin(x)
                     <tr>
                         <th>Description</th>
                         <th>MATLAB</th>
+                        <th>Scilab</th>
                         <th>Python</th>
                         <th>Julia</th>
                     </tr>
@@ -2336,12 +2675,14 @@ y = x^2 + sin(x)
                     <tr>
                         <td>Setup</td>
                         <td><code>% Not available natively</code></td>
+                        <td><code>// Not available natively</code></td>
                         <td><code>import torch</code></td>
                         <td><code>using Enzyme</code></td>
                     </tr>
                     <tr>
                         <td>Gradient</td>
                         <td><code>% Not available natively</code></td>
+                        <td><code>// Not available natively</code></td>
                         <td><code>def f(x):
     return x**2 + torch.sin(x)
 
@@ -2358,6 +2699,7 @@ autodiff(Reverse, f, Active, Duplicated(x, Ref(dx)))
                     <tr>
                         <td>Vector gradient</td>
                         <td><code>% Not available natively</code></td>
+                        <td><code>// Not available natively</code></td>
                         <td><code>def f(x):
     return torch.sum(x**2)
 
@@ -2374,6 +2716,7 @@ autodiff(Reverse, f, Active, Duplicated(x, dx))
                     <tr>
                         <td>Jacobian-vector product (JVP)</td>
                         <td><code>% Not available natively</code></td>
+                        <td><code>// Not available natively</code></td>
                         <td><code>from torch.autograd.functional import jvp
 
 def f(x):
@@ -2391,6 +2734,7 @@ y, jvp = autodiff(Forward, f, Duplicated, Duplicated(x, v))
                     <tr>
                         <td>Vector-Jacobian product (VJP)</td>
                         <td><code>% Not available natively</code></td>
+                        <td><code>// Not available natively</code></td>
                         <td><code>def f(x):
     return torch.stack([x[0]**2, x[0]*x[1], x[1]**2])
 
@@ -2415,6 +2759,7 @@ autodiff(Reverse, f!, Const,
                     <tr>
                         <td>Consistency requirements</td>
                         <td><code>% N/A</code></td>
+                        <td><code>// N/A</code></td>
                         <td><code># Must replace ALL NumPy/SciPy calls:
 # np.exp → torch.exp
 # scipy functions → not compatible
@@ -2439,7 +2784,9 @@ autodiff(Reverse, f!, Const,
                     <li>SciPy solvers on CasADi functions - must use CasADi's own solvers</li>
                     <li>NumPy operations on symbolic expressions - use CasADi operations</li>
                 </ul>
-                <p style="margin-top: 10px;">Julia's ModelingToolkit.jl uses the same solvers from earlier sections (DifferentialEquations.jl, NonlinearSolve.jl, Optimization.jl).</p>
+                <p style="margin-top: 10px;">Julia's ModelingToolkit.jl 
+uses the same solvers from earlier sections (DifferentialEquations.jl, 
+NonlinearSolve.jl, Optimization.jl).</p>
             </div>
 
             <h3>System Definition</h3>
@@ -2448,6 +2795,7 @@ autodiff(Reverse, f!, Const,
                     <tr>
                         <th>Description</th>
                         <th>MATLAB</th>
+                        <th>Scilab</th>
                         <th>Python</th>
                         <th>Julia</th>
                     </tr>
@@ -2456,6 +2804,7 @@ autodiff(Reverse, f!, Const,
                     <tr>
                         <td>Define ODE system (Cartesian pendulum)</td>
                         <td><code>% Use Simulink or write function</code></td>
+                        <td><code>// Use Xcos or write function</code></td>
                         <td><code>import casadi as ca
 
 x = ca.SX.sym('x')
@@ -2486,6 +2835,7 @@ eqs = [D(x) ~ vx,
                     <tr>
                         <td>Simplify system</td>
                         <td><code>% Manual simplification</code></td>
+                        <td><code>// Manual simplification</code></td>
                         <td><code># CasADi cannot do acausal simplification</code></td>
                         <td><code>pendulum = complete(pendulum)
 pendulum_simplified = mtkcompile(pendulum)</code></td>
@@ -2493,14 +2843,15 @@ pendulum_simplified = mtkcompile(pendulum)</code></td>
                     <tr>
                         <td>Transient simulation</td>
                         <td><code>% Create function handle and solve</code></td>
+                        <td><code>// Create function handle and solve</code></td>
                         <td><code># Note: CasADi cannot directly solve
 # this DAE model - would need integrator
 # setup with algebraic constraints,
 # high index causes instability</code></td>
-                        <td><code>u0 = [x => 1.0, y => 0.0,
-      vx => 0.0, vy => 0.0]
+                        <td><code>u0 = [x =&gt; 1.0, y =&gt; 0.0,
+      vx =&gt; 0.0, vy =&gt; 0.0]
 tspan = (0.0, 10.0)
-p = [g => 9.81, L => 1.0]
+p = [g =&gt; 9.81, L =&gt; 1.0]
 
 prob = ODEProblem(pendulum_simplified, u0, tspan, p)
 sol = solve(prob)</code></td>
@@ -2508,6 +2859,7 @@ sol = solve(prob)</code></td>
                     <tr>
                         <td>Steady state solutions</td>
                         <td><code>% Use fsolve or symbolic solve</code></td>
+                        <td><code>// Use fsolve or symbolic solve</code></td>
                         <td><code># CasADi has its own rootfinder
 import casadi as ca
 # Create rootfinder for algebraic equations
@@ -2520,6 +2872,7 @@ ss_sol = solve(ss_prob)</code></td>
                     <tr>
                         <td>Generate LaTeX</td>
                         <td><code>% Not available for Simulink models</code></td>
+                        <td><code>// Not available for Xcos models</code></td>
                         <td><code># Not available in CasADi</code></td>
                         <td><code>using Latexify
 latexify(pendulum)</code></td>
@@ -2534,6 +2887,7 @@ latexify(pendulum)</code></td>
                     <tr>
                         <th>Description</th>
                         <th>MATLAB</th>
+                        <th>Scilab</th>
                         <th>Python</th>
                         <th>Julia</th>
                     </tr>
@@ -2542,6 +2896,7 @@ latexify(pendulum)</code></td>
                     <tr>
                         <td>Create component</td>
                         <td><code>% Use Simulink blocks</code></td>
+                        <td><code>% Use Xcos blocks</code></td>
                         <td><code># No direct equivalent
 # Consider PyMola or OpenModelica</code></td>
                         <td><code>function Mass(; name, m = 1.0,
@@ -2562,6 +2917,7 @@ end
                     <tr>
                         <td>Connect systems</td>
                         <td><code>% Simulink connections</code></td>
+                        <td><code>% Xcos connections</code></td>
                         <td><code># Manual composition</code></td>
                         <td><code>@named spring = Spring(k = 100)
 @named damper = Damper(c = 10)
@@ -2579,6 +2935,7 @@ model = complete(model)</code></td>
                     <tr>
                         <td>Simplify</td>
                         <td><code>% Simulink cannot simplify</code></td>
+                        <td><code>% Xcos cannot simplify</code></td>
                         <td><code># Manual</code></td>
                         <td><code>model_simplified = mtkcompile(model)</code></td>
                     </tr>
@@ -2619,6 +2976,23 @@ model = complete(model)</code></td>
                 }
             });
         });
+        
+        document.getElementById("matlab").addEventListener("click", function (e) {
+          document.body.classList.toggle('hidematlab');
+        });
+
+        document.getElementById("scilab").addEventListener("click", function (e) {
+          document.body.classList.toggle('hidescilab');     
+        });
+
+        document.getElementById("python").addEventListener("click", function (e) {
+          document.body.classList.toggle('hidepython');     
+        });
+
+        document.getElementById("julia").addEventListener("click", function (e) {
+          document.body.classList.toggle('hidejulia');     
+        });
     </script>
-</body>
-</html>
+
+</body></html>
+


### PR DESCRIPTION
## Summary
This PR rebases changes from [SciML/Julia_Modeling_Workshop#3](https://github.com/SciML/Julia_Modeling_Workshop/pull/3) onto the Scientific_Modeling_Cheatsheet repository.

The changes add:
- **Scilab column**: Adds Scilab syntax alongside existing MATLAB, Python, and Julia examples
- **Hide/show mechanism**: Implements a feature to show/hide language columns for better readability

## Original PR Details
- Original PR: https://github.com/SciML/Julia_Modeling_Workshop/pull/3
- Original Author: Stéphane MOTTELET (@mottelet)
- Original PR included 7 commits with various fixes and improvements

## Changes
The file `scientific_modeling_cheatsheet.html` has been updated with:
- ~3000 lines added
- ~2600 lines removed/modified
- Interactive column visibility controls
- Scilab language syntax examples

## Test Plan
- [ ] Verify the HTML file renders correctly in a browser
- [ ] Test the hide/show mechanism for each language column
- [ ] Verify Scilab syntax examples are accurate

🤖 Generated with [Claude Code](https://claude.com/claude-code)